### PR TITLE
Add function to allow downloading compiler for other architecture

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -9,20 +9,64 @@ jobs:
       matrix:
         version: ['version-1-0', 'version-1-4', 'devel']
         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        arch: ['', 'amd64', 'i386']
         customDir: ['', 'install-nim-here', 'dir with spaces']
         addPath: [true, false]
+        exclude:
+          - os: macos-latest
+            arch: i386
+        include:
+          - os: windows-latest
+            arch: ''
+            mingw: x64
+          - os: windows-latest
+            arch: amd64
+            mingw: x64
+          - os: windows-latest
+            arch: i386
+            mingw: x32
+          - os: ubuntu-latest
+            shell: bash
+          - os: macos-latest
+            shell: bash
 
-    name: '${{ matrix.os }}(path: ${{ matrix.customDir }}, add-to-path: ${{ matrix.addPath }}, version: ${{ matrix.version }})'
+    name: '${{ matrix.os }}(arch: ${{ matrix.arch }}, path: ${{ matrix.customDir }}, add-to-path: ${{ matrix.addPath }}, version: ${{ matrix.version }})'
     runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2
 
+      - if: matrix.arch == 'i386' && runner.os == 'Linux'
+        name: Setup 32bit compiler (Linux)
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-fast update -qq
+          sudo DEBIAN_FRONTEND='noninteractive' apt-fast install \
+            --no-install-recommends -yq gcc-multilib g++-multilib
+          mkdir -p ~/.config/nim
+          nimcfg=$HOME/.config/nim/nim.cfg
+
+          cat << EOF > ~/.config/nim/nim.cfg
+          passC = "-m32"
+          passL = "-m32"
+          EOF
+
+      - if: runner.os == 'Windows'
+        name: Setup MinGW (Windows)
+        uses: egor-tensin/setup-mingw@v1
+        with:
+          platform: ${{ matrix.mingw }}
+
       - if: matrix.customDir == ''
         name: Install Nim (default subdir)
         uses: ./
         with:
+          architecture: ${{ matrix.arch }}
           add-to-path: ${{ matrix.addPath }}
           version: ${{ matrix.version }}
 
@@ -30,18 +74,17 @@ jobs:
         name: Install Nim (custom subdir)
         uses: ./
         with:
+          architecture: ${{ matrix.arch }}
           path: ${{ matrix.customDir }}
           add-to-path: ${{ matrix.addPath }}
           version: ${{ matrix.version }}
 
       - if: matrix.addPath
         name: Verify installation in PATH
-        shell: bash
         run: nim -v
 
       - if: '! matrix.addPath'
         name: Verify installation not in PATH
-        shell: bash
         run: |
           if ! which nim >/dev/null 2>&1; then
             echo "Test passed!"
@@ -51,7 +94,6 @@ jobs:
           fi
 
       - name: Verify installation version and whether it is in the correct folder
-        shell: bash
         run: |
           directory='${{ matrix.customDir }}'
           [[ -z "$directory" ]] && directory=nim
@@ -74,7 +116,6 @@ jobs:
           fi
 
       - name: Check if the compiler works
-        shell: bash
         run: |
           cat << EOF > test.nim
           import strutils
@@ -106,7 +147,6 @@ jobs:
       # containing whitespaces.
       - if: matrix.addPath && ! contains(matrix.customDir, ' ')
         name: Check if nimble works
-        shell: bash
         run: |
           nimble install -y nimterop
           if ! command -v toast >/dev/null 2>&1; then

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Download and install the selected Nim nightly build'
 
 inputs:
   architecture:
-    description: 'What architecture of the compiler should be fetched'
+    description: 'What architecture of the compiler should be fetched (defaults to native)'
     required: false
   version:
     description: 'Which nightly-tracked branch should be fetched'

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,9 @@ name: 'Setup Nim compiler and tools'
 description: 'Download and install the selected Nim nightly build'
 
 inputs:
+  architecture:
+    description: 'What architecture of the compiler should be fetched'
+    required: false
   version:
     description: 'Which nightly-tracked branch should be fetched'
     required: true
@@ -21,7 +24,7 @@ runs:
     - name: 'Download the Nim compiler'
       shell: bash
       run: |
-        '${{ github.action_path }}/setup.sh' -o '${{ inputs.path }}' '${{ inputs.version }}'
+        '${{ github.action_path }}/setup.sh' -o '${{ inputs.path }}' '${{ inputs.version }}' '${{ inputs.architecture }}'
 
     - name: 'Enable annotations support'
       shell: bash

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,27 @@ jobs:
       - run: nimble test
 ```
 
+Testing 32bit Windows:
+
+```yaml
+jobs:
+  test:
+    name: Nim 32bit on Windows
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: egor-tensin/setup-mingw@v1
+        with:
+          platform: x86
+      - uses: alaviss/setup-nim@master
+        with:
+          path: 'nim'
+          version: devel
+          architecture: i386
+      - run: nimble test
+```
+
 # License
 
 Unless stated otherwise, scripts and documentations within this project are


### PR DESCRIPTION
Ref #2 

This allows for "native" cross-compilation to other architectures, though it will mostly be useful for compiling 32-bit from x86_64. `readme.md` has been updated with guide on how to test your software on 32-bit Windows.

The procedure for testing 32-bit Linux is still a PITA and users should just setup cross-compilation for now.