### PR TITLE
action(github): convert PATH to Windows-style

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -112,3 +112,11 @@ jobs:
           if ! command -v toast >/dev/null 2>&1; then
             echo "Error: could not find toast"
           fi
+
+      - if: runner.os == 'Windows' && matrix.addPath && ! contains(matrix.customDir, ' ')
+        name: Check if PATH is correct for native Windows software
+        shell: powershell
+        run: |
+          Get-Command "toast.cmd" -ErrorAction Stop | out-null
+          Get-Command "nim.exe" -ErrorAction Stop | out-null
+          Write-Host "Test passed"

--- a/action.yml
+++ b/action.yml
@@ -35,12 +35,18 @@ runs:
           echo "Directory '$1' has been added to PATH."
         }
 
+        real-path() {
+          if [[ '${{ runner.os }}' == 'Windows' ]]; then
+            cygpath -aw "$1"
+          else
+            python -c "import os; import sys; print(os.path.realpath(sys.argv[1]))" "$1"
+          fi
+        }
+
         if ${{ inputs.add-to-path }}; then
           path='${{ inputs.path }}'
-          path=$(python -c "import os; import sys; print(os.path.realpath(sys.argv[1]))" "$path")
-          path=$path/bin
-          add-path "$path"
-          add-path "$HOME/.nimble/bin"
+          add-path "$(real-path "$path/bin")"
+          add-path "$(real-path "$HOME/.nimble/bin")"
         else
           echo "This step was skipped per user request."
         fi


### PR DESCRIPTION
`git-bash` paths (ie. '/c/user/.nimble/bin') are not supported by native
Windows software, which makes `~/.nimble/bin` added via the action unusable
by native Windows software (incl. the nim compiler).

This commit converts them into native paths before adding them to PATH.